### PR TITLE
Craft 5 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "swishdigital/template-selector",
     "description": "A fieldtype that allows you to select a template from a dropdown.",
     "type": "craft-plugin",
-    "version": "1.0.7",
+    "version": "5.0.0",
     "keywords": [
         "craft",
         "cms",
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.0.0|^4.0.0-alpha.1"
+        "craftcms/cms": "^3.0.0|^4.0.0-alpha.1|^5.0.x-dev|^5.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Adds Craft 5 compatibility and edits plugin version to be in line with Crafts new versioning system e.g. Craft 4 plugins follow 4.x.x, Craft 5 follows 5.x.x